### PR TITLE
Upgrade cson-parser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "cson-parser": "^1.2.0",
+    "cson-parser": "^3.0.0",
     "js-yaml": "^3.3.0",
     "lodash": "^3.10.0"
   },
@@ -26,7 +26,8 @@
     "grunt-contrib-watch": "^0.6.0",
     "grunt-mocha-test": "^0.12.0",
     "grunt-exec": "^0.4.6",
-    "spacejam": "^1.2.0"
+    "spacejam": "^1.2.0",
+    "mocha": "^2.4.5"
   },
   "keywords": [
     "replace",


### PR DESCRIPTION
Recently coffee-script module has been renamed to coffeescript. You can read more details on their NPM package https://www.npmjs.com/package/coffee-script.

coffee-script had accidentally released coffee-script1.12.28 which was then reverted. More details available  here: https://github.com/npm/registry/issues/248

Since applause uses cson-parser and it in turn uses coffeescript, we need upgrade cson-parser to the latest. 

This PR upgrades cson-parser to 3.0.0 and also adds the missing mocha devDependency

Please review & accept the PR and please release a new version. I plan to then send you a separate PR on grunt-replace to upgrade applause dependency in it.  

